### PR TITLE
fix(tap): Update the url to the brevo API.

### DIFF
--- a/tap_sendinblue/tap.py
+++ b/tap_sendinblue/tap.py
@@ -31,7 +31,7 @@ class TapSendInBlue(Tap):
         th.Property(
             "api_url",
             th.StringType,
-            default="https://api.sendinblue.com/v3",
+            default="https://api.brevo.com/v3/",
             description="The url for the API service",
         ),
     ).to_dict()


### PR DESCRIPTION
[SIG-210](https://gupy-io.atlassian.net/browse/SIG-210)
- Atualização do rota para extração de dados do Brevo (Sendinblue)

[SIG-210]: https://gupy-io.atlassian.net/browse/SIG-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ